### PR TITLE
Fix: Addressing issue #123 - Got error in smart-pr-prod.payment_set_dw.sp_payment_tracker procedure

### DIFF
--- a/sp_payment_tracker.sql
+++ b/sp_payment_tracker.sql
@@ -10,7 +10,7 @@ BEGIN
   MERGE `project_name.payment_set_dw.dw_payment_tracker` T
   USING(
       SELECT 
-      CAST(user_name || '-' || event_data || '-' || region AS STRING) AS integration_id,
+      CAST(COALESCE(user_name, '') || '-' || COALESCE(event_data, '') || '-' || COALESCE(region, '') AS STRING) AS integration_id,
       user_name,
       event_data,
       amount,


### PR DESCRIPTION
This PR addresses issue #123.

Required field integration_id cannot be null at [smart-pr-prod.payment_set_dw.sp_payment_tracker:4:4]