### PR TITLE
Fix: Addressing issue #123 - Got error in smart-pr-prod.contact_raw.contact_table column not found

### DIFF
--- a/contact_table.sql
+++ b/contact_table.sql
@@ -3,7 +3,6 @@ CREATE TABLE IF NOT EXISTS `project_name.contact_raw.contact_table` (
   `first_name` STRING,
   `last_name` STRING,
   `email` STRING,
-  `phone_number` STRING,
   `location` STRING,
   `age` INT64,
   `gender` STRING,


### PR DESCRIPTION
This PR addresses issue #123.

phone_number column is not present in contact table. Please remove the column from the table ddl