### PR TITLE
Fix: Addressing issue #123 - Column clause_type not found inside the clauses table

### DIFF
--- a/bigquery/dl/clauses.sql
+++ b/bigquery/dl/clauses.sql
@@ -1,7 +1,6 @@
 CREATE TABLE `project_name.helix_agiloft_dl.clauses` (
   clause_id STRING(50) NOT NULL,
   contract_id STRING(50) NOT NULL,
-  clause_type STRING(100) NOT NULL,
   clause_title STRING(300),
   clause_text STRING(5000),
   is_standard_clause BOOLEAN DEFAULT FALSE,

--- a/bigquery/raw/clauses.sql
+++ b/bigquery/raw/clauses.sql
@@ -1,7 +1,6 @@
 CREATE TABLE `project_name.helix_agiloft_raw.clauses` (
   clause_id STRING(50) NOT NULL,
   contract_id STRING(50) NOT NULL,
-  clause_type STRING(100) NOT NULL,
   clause_title STRING(300),
   clause_text STRING(5000),
   is_standard_clause BOOLEAN DEFAULT FALSE,

--- a/gcs_files/schemas/clauses.json
+++ b/gcs_files/schemas/clauses.json
@@ -1,7 +1,6 @@
 [
   {"name": "clause_id",             "type": "STRING",   "mode": "REQUIRED"},
   {"name": "contract_id",           "type": "STRING",   "mode": "REQUIRED"},
-  {"name": "clause_type",           "type": "STRING",   "mode": "REQUIRED"},
   {"name": "clause_title",          "type": "STRING",   "mode": "NULLABLE"},
   {"name": "clause_text",           "type": "STRING",   "mode": "NULLABLE"},
   {"name": "is_standard_clause",    "type": "BOOLEAN",  "mode": "NULLABLE"},


### PR DESCRIPTION
This PR addresses issue #123.

Remove clause_type column from stg, raw, dl schemas of clauses table and also from the dag