### PR TITLE
Fix: Addressing issue #123 - Column contract_id not found inside the clauses table

### DIFF
--- a/bigquery/dl/clauses.sql
+++ b/bigquery/dl/clauses.sql
@@ -1,6 +1,5 @@
 CREATE TABLE `project_name.helix_agiloft_dl.clauses` (
   clause_id STRING(50) NOT NULL,
-  contract_id STRING(50) NOT NULL,
   clause_type STRING(100) NOT NULL,
   clause_title STRING(300),
   clause_text STRING(5000),

--- a/bigquery/raw/clauses.sql
+++ b/bigquery/raw/clauses.sql
@@ -1,6 +1,5 @@
 CREATE TABLE `project_name.helix_agiloft_raw.clauses` (
   clause_id STRING(50) NOT NULL,
-  contract_id STRING(50) NOT NULL,
   clause_type STRING(100) NOT NULL,
   clause_title STRING(300),
   clause_text STRING(5000),

--- a/gcs_files/schemas/clauses.json
+++ b/gcs_files/schemas/clauses.json
@@ -1,6 +1,5 @@
 [
   {"name": "clause_id",             "type": "STRING",   "mode": "REQUIRED"},
-  {"name": "contract_id",           "type": "STRING",   "mode": "REQUIRED"},
   {"name": "clause_type",           "type": "STRING",   "mode": "REQUIRED"},
   {"name": "clause_title",          "type": "STRING",   "mode": "NULLABLE"},
   {"name": "clause_text",           "type": "STRING",   "mode": "NULLABLE"},


### PR DESCRIPTION
This PR addresses issue #123.

Remove contract_id column from stg, raw, dl schemas of clauses table and also from the dag