### PR TITLE
Fix: Addressing issue #57 - Got error in smart-pr-prod.payment_set_dw.sp_payment_tracker procedure.

### DIFF
--- a/old_files/sp_payment_tracker.sql
+++ b/old_files/sp_payment_tracker.sql
@@ -21,6 +21,9 @@ BEGIN
       updated_at
       FROM `project_name.payment_set_raw.payment_tracker` 
       WHERE updated_at BETWEEN p_from_delta AND p_to_delta
+      AND user_name IS NOT NULL
+      AND event_data IS NOT NULL
+      AND region IS NOT NULL
   ) S
   ON T.integration_id = S.integration_id
   WHEN MATCHED THEN


### PR DESCRIPTION
This PR addresses issue #57.

Required field integration_id cannot be null at [smart-pr-prod.payment_set_dw.sp_payment_tracker:4:4]